### PR TITLE
Enable SQLite migrations

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,16 +15,55 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('surname');
+            $table->char('surname', 10);
             $table->string('first_name');
             $table->string('last_name')->nullable();
-            $table->string('username')->unique();
+            $table->string('user_type')->default('user')->index();
+            $table->string('username')->nullable()->unique();
             $table->string('email')->nullable();
-            $table->string('password');
+            $table->string('password')->nullable();
             $table->char('language', 7)->default('en');
+            $table->char('contact_no', 15)->nullable();
+            $table->text('address')->nullable();
+            $table->integer('business_id')->unsigned()->nullable();
+            $table->boolean('allow_login')->default(1);
+            $table->boolean('is_cmmsn_agnt')->default(0);
+            $table->decimal('cmmsn_percent', 4, 2)->default(0);
+            $table->boolean('selected_contacts')->default(false);
+            $table->enum('status', ['active', 'inactive', 'terminated'])->default('active');
+            $table->decimal('max_sales_discount_percent', 5, 2)->nullable();
+            $table->date('dob')->nullable();
+            $table->enum('marital_status', ['married', 'unmarried', 'divorced'])->nullable();
+            $table->char('blood_group', 10)->nullable();
+            $table->char('contact_number', 20)->nullable();
+            $table->string('fb_link')->nullable();
+            $table->string('twitter_link')->nullable();
+            $table->string('social_media_1')->nullable();
+            $table->string('social_media_2')->nullable();
+            $table->text('permanent_address')->nullable();
+            $table->text('current_address')->nullable();
+            $table->string('guardian_name')->nullable();
+            $table->string('custom_field_1')->nullable();
+            $table->string('custom_field_2')->nullable();
+            $table->string('custom_field_3')->nullable();
+            $table->string('custom_field_4')->nullable();
+            $table->longText('bank_details')->nullable();
+            $table->string('id_proof_name')->nullable();
+            $table->string('id_proof_number')->nullable();
+            $table->string('gender')->nullable();
+            $table->string('alt_number')->nullable();
+            $table->string('family_number')->nullable();
+            $table->boolean('is_enable_service_staff_pin')->default(0);
+            $table->text('service_staff_pin')->nullable();
+            $table->dateTime('available_at')->nullable();
+            $table->dateTime('paused_at')->nullable();
+            $table->integer('crm_contact_id')->unsigned()->nullable();
             $table->rememberToken();
             $table->softDeletes();
             $table->timestamps();
+
+            $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+            $table->foreign('crm_contact_id')->references('id')->on('contacts')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2017_07_05_073658_create_business_table.php
+++ b/database/migrations/2017_07_05_073658_create_business_table.php
@@ -27,6 +27,8 @@ return new class extends Migration
             $table->float('default_profit_percent', 5, 2)->default(0);
             $table->integer('owner_id')->unsigned();
             $table->foreign('owner_id')->references('id')->on('users')->onDelete('cascade');
+            $table->integer('default_sales_tax')->unsigned()->nullable();
+            $table->foreign('default_sales_tax')->references('id')->on('tax_rates');
             $table->string('time_zone')->default('Asia/Kolkata');
             $table->tinyInteger('fy_start_month')->default(1);
             $table->enum('accounting_method', ['fifo', 'lifo', 'avco'])->default('fifo');
@@ -36,6 +38,18 @@ return new class extends Migration
             $table->string('logo')->nullable();
             $table->string('sku_prefix')->nullable();
             $table->boolean('enable_tooltip')->default(1);
+            $table->boolean('enable_inline_tax')->default(1);
+            $table->enum('currency_symbol_placement', ['before', 'after'])->default('before');
+            $table->enum('expiry_type', ['add_expiry', 'add_manufacturing'])->default('add_expiry');
+            $table->string('date_format')->default('m/d/Y');
+            $table->enum('time_format', [12, 24])->default(24);
+            $table->tinyInteger('currency_precision')->default(2);
+            $table->tinyInteger('quantity_precision')->default(2);
+            $table->char('theme_color', 20)->nullable();
+            $table->integer('created_by')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->text('weighing_scale_setting')->nullable();
+            $table->text('custom_labels')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2017_07_22_075923_add_business_id_users_table.php
+++ b/database/migrations/2017_07_22_075923_add_business_id_users_table.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->integer('business_id')->unsigned()->nullable()->after('remember_token');
-            $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
-        });
+        if (! Schema::hasColumn('users', 'business_id')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->integer('business_id')->unsigned()->nullable()->after('remember_token');
+                $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2017_08_19_054827_create_transactions_table.php
+++ b/database/migrations/2017_08_19_054827_create_transactions_table.php
@@ -17,8 +17,11 @@ return new class extends Migration
             $table->increments('id');
             $table->integer('business_id')->unsigned();
             $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
-            $table->enum('type', ['purchase','sell', 'expense']);
-            $table->enum('status', ['received', 'pending', 'ordered', 'draft', 'final']);
+            $table->unsignedInteger('location_id')->nullable();
+            $table->foreign('location_id')->references('id')->on('business_locations');
+            // store transaction type and status as varchar to avoid later ALTER statements
+            $table->string('type')->nullable();
+            $table->string('status')->nullable();
             $table->enum('payment_status', ['paid', 'due', 'partial']);
             $table->integer('contact_id')->unsigned()->nullable();
             $table->foreign('contact_id')->references('id')->on('contacts')->onDelete('cascade');
@@ -41,6 +44,7 @@ return new class extends Migration
             $table->foreign('expense_category_id')->references('id')->on('expense_categories')->onDelete('cascade');
             $table->integer('expense_for')->nullable()->unsigned();
             $table->foreign('expense_for')->references('id')->on('users')->onDelete('cascade');
+            $table->decimal('exchange_rate', 20, 3)->default(1);
 
             $table->index('expense_category_id');
             
@@ -51,6 +55,7 @@ return new class extends Migration
             //Indexing
             $table->index('business_id');
             $table->index('type');
+            $table->index('location_id');
             $table->index('contact_id');
             $table->index('transaction_date');
             $table->index('created_by');

--- a/database/migrations/2017_10_31_065621_add_default_sales_tax_to_business_table.php
+++ b/database/migrations/2017_10_31_065621_add_default_sales_tax_to_business_table.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->integer('default_sales_tax')->unsigned()->nullable()->after('tax_label_2');
-            $table->foreign('default_sales_tax')->references('id')->on('tax_rates');
-        });
+        if (! Schema::hasColumn('business', 'default_sales_tax')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->integer('default_sales_tax')->unsigned()->nullable()->after('tax_label_2');
+                $table->foreign('default_sales_tax')->references('id')->on('tax_rates');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_02_19_121537_stock_adjustment_move_to_transaction_table.php
+++ b/database/migrations/2018_02_19_121537_stock_adjustment_move_to_transaction_table.php
@@ -14,11 +14,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell','expense','stock_adjustment') DEFAULT NULL");
+        // type column stored as varchar from the beginning, so no alteration needed
 
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
-
-        DB::statement('DROP TABLE IF EXISTS stock_adjustment_lines');
+        Schema::dropIfExists('stock_adjustment_lines');
 
         Schema::create('stock_adjustment_lines', function (Blueprint $table) {
             $table->increments('id');
@@ -42,11 +40,12 @@ return new class extends Migration
             $table->decimal('total_amount_recovered', 22, 4)->comment('Used for stock adjustment.')->nullable()->after('exchange_rate');
         });
 
-        //Create & Rename stock_adjustment table.
-        DB::statement('CREATE TABLE IF NOT EXISTS `stock_adjustments` (`id` int(11) DEFAULT NULL) ');
+        //Create & Rename stock_adjustment table without raw SQL
+        Schema::create('stock_adjustments', function (Blueprint $table) {
+            $table->increments('id');
+        });
         Schema::rename('stock_adjustments', 'stock_adjustments_temp');
 
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
     }
 
     /**

--- a/database/migrations/2018_02_26_130519_modify_users_table_for_sales_cmmsn_agnt.php
+++ b/database/migrations/2018_02_26_130519_modify_users_table_for_sales_cmmsn_agnt.php
@@ -14,14 +14,19 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE users MODIFY COLUMN surname CHAR(10)');
+        if (! Schema::hasColumn('users', 'contact_no')) {
+            // Modify surname length only if using MySQL
+            if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+                DB::statement('ALTER TABLE users MODIFY COLUMN surname CHAR(10)');
+            }
 
-        Schema::table('users', function (Blueprint $table) {
-            $table->char('contact_no', 15)->nullable()->after('language');
-            $table->text('address')->nullable()->after('contact_no');
-            $table->boolean('is_cmmsn_agnt')->default(0)->after('business_id');
-            $table->decimal('cmmsn_percent', 4, 2)->default(0)->after('is_cmmsn_agnt');
-        });
+            Schema::table('users', function (Blueprint $table) {
+                $table->char('contact_no', 15)->nullable()->after('language');
+                $table->text('address')->nullable()->after('contact_no');
+                $table->boolean('is_cmmsn_agnt')->default(0)->after('business_id');
+                $table->decimal('cmmsn_percent', 4, 2)->default(0)->after('is_cmmsn_agnt');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_02_27_170232_modify_transactions_table_for_stock_transfer.php
+++ b/database/migrations/2018_02_27_170232_modify_transactions_table_for_stock_transfer.php
@@ -14,8 +14,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell', 'expense',
-            'stock_adjustment', 'sell_transfer', 'purchase_transfer', 'opening_stock') DEFAULT NULL");
+        // type column already defined as varchar in initial migration
 
         Schema::table('transactions', function (Blueprint $table) {
             $table->integer('transfer_parent_id')->nullable()->after('total_amount_recovered');

--- a/database/migrations/2018_03_05_153510_add_enable_inline_tax_column_to_business_table.php
+++ b/database/migrations/2018_03_05_153510_add_enable_inline_tax_column_to_business_table.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->boolean('enable_inline_tax')->default(1)->after('item_addition_method');
-            $table->enum('currency_symbol_placement', ['before', 'after'])->after('enable_inline_tax')->default('before');
-        });
+        if (! Schema::hasColumn('business', 'enable_inline_tax')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->boolean('enable_inline_tax')->default(1)->after('item_addition_method');
+                $table->enum('currency_symbol_placement', ['before', 'after'])->after('enable_inline_tax')->default('before');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_03_13_181541_add_expiry_type_to_business_table.php
+++ b/database/migrations/2018_03_13_181541_add_expiry_type_to_business_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->enum('expiry_type', ['add_expiry', 'add_manufacturing'])->after('enable_product_expiry')->default('add_expiry');
-        });
+        if (! Schema::hasColumn('business', 'expiry_type')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->enum('expiry_type', ['add_expiry', 'add_manufacturing'])->after('enable_product_expiry')->default('add_expiry');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_03_31_140921_update_transactions_table_exchange_rate.php
+++ b/database/migrations/2018_03_31_140921_update_transactions_table_exchange_rate.php
@@ -11,7 +11,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN exchange_rate DECIMAL(20,3) NOT NULL DEFAULT 0');
+        Schema::table('transactions', function ($table) {
+            $table->decimal('exchange_rate', 20, 3)->default(0)->change();
+        });
     }
 
     /**

--- a/database/migrations/2018_04_09_135320_change_exchage_rate_size_in_business_table.php
+++ b/database/migrations/2018_04_09_135320_change_exchage_rate_size_in_business_table.php
@@ -12,8 +12,12 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE business MODIFY COLUMN p_exchange_rate DECIMAL(20, 3) NOT NULL DEFAULT 1');
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN exchange_rate DECIMAL(20,3) NOT NULL DEFAULT 1');
+        Schema::table('business', function ($table) {
+            $table->decimal('p_exchange_rate', 20, 3)->default(1)->change();
+        });
+        Schema::table('transactions', function ($table) {
+            $table->decimal('exchange_rate', 20, 3)->default(1)->change();
+        });
 
         //Update 0 to 1
         DB::table('transactions')

--- a/database/migrations/2018_05_02_104439_add_date_format_and_time_format_to_business.php
+++ b/database/migrations/2018_05_02_104439_add_date_format_and_time_format_to_business.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->string('date_format')->default('m/d/Y')->after('enabled_modules');
-            $table->enum('time_format', [12, 24])->default(24)->after('date_format');
-        });
+        if (! Schema::hasColumn('business', 'date_format')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->string('date_format')->default('m/d/Y')->after('enabled_modules');
+                $table->enum('time_format', [12, 24])->default(24)->after('date_format');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_05_18_191956_add_sell_return_to_transaction_table.php
+++ b/database/migrations/2018_05_18_191956_add_sell_return_to_transaction_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell','expense','stock_adjustment','sell_transfer','purchase_transfer','opening_stock','sell_return') DEFAULT NULL");
+        // type column updated to string in base migration; no alteration required
     }
 
     /**

--- a/database/migrations/2018_06_27_182835_add_superadmin_related_fields_business.php
+++ b/database/migrations/2018_06_27_182835_add_superadmin_related_fields_business.php
@@ -14,10 +14,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->integer('created_by')->nullable()->after('ref_no_prefixes');
-            $table->boolean('is_active')->default(true)->after('created_by');
-        });
+        if (! Schema::hasColumn('business', 'created_by')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->integer('created_by')->nullable()->after('ref_no_prefixes');
+                $table->boolean('is_active')->default(true)->after('created_by');
+            });
+        }
 
         DB::table('system')->insert(['key' => 'default_business_active_status', 'value' => 1]);
     }

--- a/database/migrations/2018_07_17_163920_add_theme_skin_color_column_to_business_table.php
+++ b/database/migrations/2018_07_17_163920_add_theme_skin_color_column_to_business_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->char('theme_color', 20)->nullable()->after('ref_no_prefixes');
-        });
+        if (! Schema::hasColumn('business', 'theme_color')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->char('theme_color', 20)->nullable()->after('ref_no_prefixes');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_08_14_104036_add_opening_balance_type_to_transactions_table.php
+++ b/database/migrations/2018_08_14_104036_add_opening_balance_type_to_transactions_table.php
@@ -12,8 +12,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN type ENUM('purchase','sell', 'expense', 'stock_adjustment', 'sell_transfer', 'purchase_transfer', 
-            'opening_stock', 'sell_return', 'opening_balance')");
+        // base migration already stores type as varchar; no change required
     }
 
     /**

--- a/database/migrations/2018_09_27_111609_modify_transactions_table_for_purchase_return.php
+++ b/database/migrations/2018_09_27_111609_modify_transactions_table_for_purchase_return.php
@@ -14,7 +14,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN type ENUM('purchase','sell', 'expense', 'stock_adjustment', 'sell_transfer', 'purchase_transfer', 'opening_stock', 'sell_return', 'opening_balance', 'purchase_return') DEFAULT NULL");
+        // type column is varchar in base migration, no alteration needed
 
         Schema::table('transactions', function (Blueprint $table) {
             $table->integer('return_parent_id')->nullable()->after('transfer_parent_id');

--- a/database/migrations/2018_10_31_174752_add_access_selected_contacts_only_to_users_table.php
+++ b/database/migrations/2018_10_31_174752_add_access_selected_contacts_only_to_users_table.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->boolean('selected_contacts')->default(false)
-                ->after('cmmsn_percent');
-        });
+        if (! Schema::hasColumn('users', 'selected_contacts')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('selected_contacts')->default(false)
+                    ->after('cmmsn_percent');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2018_12_06_114937_modify_system_table_and_users_table.php
+++ b/database/migrations/2018_12_06_114937_modify_system_table_and_users_table.php
@@ -15,9 +15,11 @@ return new class extends Migration
     public function up()
     {
         // DB::statement("ALTER TABLE system MODIFY COLUMN `value` VARCHAR(191) DEFAULT NULL");
-        Schema::table('users', function (Blueprint $table) {
-            $table->enum('status', ['active', 'inactive', 'terminated'])->default('active')->after('business_id');
-        });
+        if (! Schema::hasColumn('users', 'status')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->enum('status', ['active', 'inactive', 'terminated'])->default('active')->after('business_id');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2019_06_17_103515_add_profile_informations_columns_to_users_table.php
+++ b/database/migrations/2019_06_17_103515_add_profile_informations_columns_to_users_table.php
@@ -13,26 +13,28 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->date('dob')->nullable()->after('selected_contacts');
-            $table->enum('marital_status', ['married', 'unmarried', 'divorced'])->nullable()->after('dob');
-            $table->char('blood_group', 10)->nullable()->after('marital_status');
-            $table->char('contact_number', 20)->nullable()->after('blood_group');
-            $table->string('fb_link')->nullable()->after('contact_number');
-            $table->string('twitter_link')->nullable()->after('fb_link');
-            $table->string('social_media_1')->nullable()->after('twitter_link');
-            $table->string('social_media_2')->nullable()->after('social_media_1');
-            $table->text('permanent_address')->nullable()->after('social_media_2');
-            $table->text('current_address')->nullable()->after('permanent_address');
-            $table->string('guardian_name')->nullable()->after('current_address');
-            $table->string('custom_field_1')->nullable()->after('guardian_name');
-            $table->string('custom_field_2')->nullable()->after('custom_field_1');
-            $table->string('custom_field_3')->nullable()->after('custom_field_2');
-            $table->string('custom_field_4')->nullable()->after('custom_field_3');
-            $table->longText('bank_details')->nullable()->after('custom_field_4');
-            $table->string('id_proof_name')->nullable()->after('bank_details');
-            $table->string('id_proof_number')->nullable()->after('id_proof_name');
-        });
+        if (! Schema::hasColumn('users', 'dob')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->date('dob')->nullable()->after('selected_contacts');
+                $table->enum('marital_status', ['married', 'unmarried', 'divorced'])->nullable()->after('dob');
+                $table->char('blood_group', 10)->nullable()->after('marital_status');
+                $table->char('contact_number', 20)->nullable()->after('blood_group');
+                $table->string('fb_link')->nullable()->after('contact_number');
+                $table->string('twitter_link')->nullable()->after('fb_link');
+                $table->string('social_media_1')->nullable()->after('twitter_link');
+                $table->string('social_media_2')->nullable()->after('social_media_1');
+                $table->text('permanent_address')->nullable()->after('social_media_2');
+                $table->text('current_address')->nullable()->after('permanent_address');
+                $table->string('guardian_name')->nullable()->after('current_address');
+                $table->string('custom_field_1')->nullable()->after('guardian_name');
+                $table->string('custom_field_2')->nullable()->after('custom_field_1');
+                $table->string('custom_field_3')->nullable()->after('custom_field_2');
+                $table->string('custom_field_4')->nullable()->after('custom_field_3');
+                $table->longText('bank_details')->nullable()->after('custom_field_4');
+                $table->string('id_proof_name')->nullable()->after('bank_details');
+                $table->string('id_proof_number')->nullable()->after('id_proof_name');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2019_06_28_133732_change_type_column_to_string_in_transactions_table.php
+++ b/database/migrations/2019_06_28_133732_change_type_column_to_string_in_transactions_table.php
@@ -12,11 +12,11 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN type VARCHAR(191) DEFAULT NULL');
-        DB::statement('ALTER TABLE transactions ADD INDEX (type);');
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-        DB::statement('ALTER TABLE  transactions CHANGE  location_id  location_id INT( 10 ) UNSIGNED NULL ;');
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        Schema::table('transactions', function ($table) {
+            $table->string('type')->nullable()->change();
+            $table->unsignedInteger('location_id')->nullable()->change();
+            $table->index('type');
+        });
     }
 
     /**

--- a/database/migrations/2019_09_17_122522_add_custom_labels_column_to_business_table.php
+++ b/database/migrations/2019_09_17_122522_add_custom_labels_column_to_business_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->text('custom_labels')->nullable()->after('sms_settings');
-        });
+        if (! Schema::hasColumn('business', 'custom_labels')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->text('custom_labels')->nullable()->after('sms_settings');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2019_11_21_162913_change_quantity_field_types_to_decimal.php
+++ b/database/migrations/2019_11_21_162913_change_quantity_field_types_to_decimal.php
@@ -12,11 +12,17 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE purchase_lines MODIFY COLUMN quantity DECIMAL(22, 4) NOT NULL DEFAULT  '0'");
+        Schema::table('purchase_lines', function ($table) {
+            $table->decimal('quantity', 22, 4)->default(0)->change();
+        });
 
-        DB::statement("ALTER TABLE transaction_sell_lines MODIFY COLUMN quantity DECIMAL(22, 4) NOT NULL DEFAULT  '0'");
+        Schema::table('transaction_sell_lines', function ($table) {
+            $table->decimal('quantity', 22, 4)->default(0)->change();
+        });
 
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN discount_amount DECIMAL(22, 4) DEFAULT  '0'");
+        Schema::table('transactions', function ($table) {
+            $table->decimal('discount_amount', 22, 4)->default(0)->change();
+        });
     }
 
     /**

--- a/database/migrations/2019_12_05_183955_add_more_fields_to_users_table.php
+++ b/database/migrations/2019_12_05_183955_add_more_fields_to_users_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->string('gender')->nullable()->after('dob');
-        });
+        if (! Schema::hasColumn('users', 'gender')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('gender')->nullable()->after('dob');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_01_28_162345_add_weighing_scale_settings_in_business_settings_table.php
+++ b/database/migrations/2020_01_28_162345_add_weighing_scale_settings_in_business_settings_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->text('weighing_scale_setting')->after('pos_settings')->comment('used to store the configuration of weighing scale');
-        });
+        if (! Schema::hasColumn('business', 'weighing_scale_setting')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->text('weighing_scale_setting')->after('pos_settings')->comment('used to store the configuration of weighing scale');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_03_26_124736_add_allow_login_column_in_users_table.php
+++ b/database/migrations/2020_03_26_124736_add_allow_login_column_in_users_table.php
@@ -14,12 +14,16 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->boolean('allow_login')->default(1)->after('business_id');
-        });
+        if (! Schema::hasColumn('users', 'allow_login')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('allow_login')->default(1)->after('business_id');
+            });
+        }
 
-        DB::statement('ALTER TABLE users CHANGE username username VARCHAR(191) NULL;');
-        DB::statement('ALTER TABLE users CHANGE password password VARCHAR(191) NULL;');
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            DB::statement('ALTER TABLE users CHANGE username username VARCHAR(191) NULL;');
+            DB::statement('ALTER TABLE users CHANGE password password VARCHAR(191) NULL;');
+        }
     }
 
     /**

--- a/database/migrations/2020_04_15_151802_add_user_type_to_users_table.php
+++ b/database/migrations/2020_04_15_151802_add_user_type_to_users_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->string('user_type')->default('user')->index()->after('id');
-        });
+        if (! Schema::hasColumn('users', 'user_type')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('user_type')->default('user')->index()->after('id');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_06_01_094654_add_max_sale_discount_column_to_users_table.php
+++ b/database/migrations/2020_06_01_094654_add_max_sale_discount_column_to_users_table.php
@@ -13,9 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->decimal('max_sales_discount_percent', 5, 2)->nullable()->after('business_id');
-        });
+        if (! Schema::hasColumn('users', 'max_sales_discount_percent')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->decimal('max_sales_discount_percent', 5, 2)->nullable()->after('business_id');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_07_23_104933_change_status_column_to_varchar_in_transaction_table.php
+++ b/database/migrations/2020_07_23_104933_change_status_column_to_varchar_in_transaction_table.php
@@ -13,7 +13,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN `status` VARCHAR(191) NOT NULL;');
+        Schema::table('transactions', function ($table) {
+            $table->string('status')->change();
+        });
 
         Transaction::where('type', 'sell_transfer')
                 ->update(['status' => 'final']);

--- a/database/migrations/2021_02_08_175632_add_contact_number_fields_to_users_table.php
+++ b/database/migrations/2021_02_08_175632_add_contact_number_fields_to_users_table.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->string('alt_number')->nullable()->after('contact_number');
-            $table->string('family_number')->nullable()->after('alt_number');
-        });
+        if (! Schema::hasColumn('users', 'alt_number')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('alt_number')->nullable()->after('contact_number');
+                $table->string('family_number')->nullable()->after('alt_number');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2021_08_25_114932_add_payment_link_fields_to_transaction_payments_table.php
+++ b/database/migrations/2021_08_25_114932_add_payment_link_fields_to_transaction_payments_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transaction_payments MODIFY COLUMN created_by INT(11) DEFAULT NULL');
+        Schema::table('transaction_payments', function (Blueprint $table) {
+            $table->integer('created_by')->nullable()->change();
+        });
 
         Schema::table('transaction_payments', function (Blueprint $table) {
             $table->boolean('paid_through_link')->default(0)->after('created_by');

--- a/database/migrations/2022_06_13_123135_add_currency_precision_and_quantity_precision_fields_to_business_table.php
+++ b/database/migrations/2022_06_13_123135_add_currency_precision_and_quantity_precision_fields_to_business_table.php
@@ -14,10 +14,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('business', function (Blueprint $table) {
-            $table->tinyInteger('currency_precision')->default(2)->after('time_format');
-            $table->tinyInteger('quantity_precision')->default(2)->after('currency_precision');
-        });
+        if (! Schema::hasColumn('business', 'currency_precision')) {
+            Schema::table('business', function (Blueprint $table) {
+                $table->tinyInteger('currency_precision')->default(2)->after('time_format');
+                $table->tinyInteger('quantity_precision')->default(2)->after('currency_precision');
+            });
+        }
 
         //clear blade directive cache
         Artisan::call('view:clear');

--- a/database/migrations/2022_08_25_132707_add_service_staff_timer_fields_to_products_and_users_table.php
+++ b/database/migrations/2022_08_25_132707_add_service_staff_timer_fields_to_products_and_users_table.php
@@ -13,14 +13,18 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('products', function (Blueprint $table) {
-            $table->integer('preparation_time_in_minutes')->nullable()->after('created_by');
-        });
+        if (! Schema::hasColumn('products', 'preparation_time_in_minutes')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->integer('preparation_time_in_minutes')->nullable()->after('created_by');
+            });
+        }
 
-        Schema::table('users', function (Blueprint $table) {
-            $table->dateTime('available_at')->nullable()->after('business_id')->comment('Service staff avilable at. Calculated from product preparation_time_in_minutes');
-            $table->dateTime('paused_at')->nullable()->after('available_at')->comment('Service staff available time paused at, Will be nulled on resume.');
-        });
+        if (! Schema::hasColumn('users', 'available_at')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dateTime('available_at')->nullable()->after('business_id')->comment('Service staff avilable at. Calculated from product preparation_time_in_minutes');
+                $table->dateTime('paused_at')->nullable()->after('available_at')->comment('Service staff available time paused at, Will be nulled on resume.');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2023_09_13_153555_add_service_staff_pin_columns_in_users.php
+++ b/database/migrations/2023_09_13_153555_add_service_staff_pin_columns_in_users.php
@@ -13,10 +13,12 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->boolean('is_enable_service_staff_pin')->default(0)->after('status');
-            $table->text('service_staff_pin')->nullable()->after('is_enable_service_staff_pin');
-        });
+        if (! Schema::hasColumn('users', 'is_enable_service_staff_pin')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('is_enable_service_staff_pin')->default(0)->after('status');
+                $table->text('service_staff_pin')->nullable()->after('is_enable_service_staff_pin');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- bundle `users` table mods into its creation migration
- merge business table modifications into its creation migration
- skip duplicate alters if columns already exist

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685af48dc760832586be1bd01296aa9c