### PR TITLE
Remove ALTER TABLE statements

### DIFF
--- a/database/migrations/2017_08_19_054827_create_transactions_table.php
+++ b/database/migrations/2017_08_19_054827_create_transactions_table.php
@@ -17,8 +17,11 @@ return new class extends Migration
             $table->increments('id');
             $table->integer('business_id')->unsigned();
             $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
-            $table->enum('type', ['purchase','sell', 'expense']);
-            $table->enum('status', ['received', 'pending', 'ordered', 'draft', 'final']);
+            $table->unsignedInteger('location_id')->nullable();
+            $table->foreign('location_id')->references('id')->on('business_locations');
+            // store transaction type and status as varchar to avoid later ALTER statements
+            $table->string('type')->nullable();
+            $table->string('status')->nullable();
             $table->enum('payment_status', ['paid', 'due', 'partial']);
             $table->integer('contact_id')->unsigned()->nullable();
             $table->foreign('contact_id')->references('id')->on('contacts')->onDelete('cascade');
@@ -41,6 +44,7 @@ return new class extends Migration
             $table->foreign('expense_category_id')->references('id')->on('expense_categories')->onDelete('cascade');
             $table->integer('expense_for')->nullable()->unsigned();
             $table->foreign('expense_for')->references('id')->on('users')->onDelete('cascade');
+            $table->decimal('exchange_rate', 20, 3)->default(1);
 
             $table->index('expense_category_id');
             
@@ -51,6 +55,7 @@ return new class extends Migration
             //Indexing
             $table->index('business_id');
             $table->index('type');
+            $table->index('location_id');
             $table->index('contact_id');
             $table->index('transaction_date');
             $table->index('created_by');

--- a/database/migrations/2018_02_19_121537_stock_adjustment_move_to_transaction_table.php
+++ b/database/migrations/2018_02_19_121537_stock_adjustment_move_to_transaction_table.php
@@ -14,11 +14,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell','expense','stock_adjustment') DEFAULT NULL");
+        // type column stored as varchar from the beginning, so no alteration needed
 
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
-
-        DB::statement('DROP TABLE IF EXISTS stock_adjustment_lines');
+        Schema::dropIfExists('stock_adjustment_lines');
 
         Schema::create('stock_adjustment_lines', function (Blueprint $table) {
             $table->increments('id');
@@ -42,11 +40,12 @@ return new class extends Migration
             $table->decimal('total_amount_recovered', 22, 4)->comment('Used for stock adjustment.')->nullable()->after('exchange_rate');
         });
 
-        //Create & Rename stock_adjustment table.
-        DB::statement('CREATE TABLE IF NOT EXISTS `stock_adjustments` (`id` int(11) DEFAULT NULL) ');
+        //Create & Rename stock_adjustment table without raw SQL
+        Schema::create('stock_adjustments', function (Blueprint $table) {
+            $table->increments('id');
+        });
         Schema::rename('stock_adjustments', 'stock_adjustments_temp');
 
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
     }
 
     /**

--- a/database/migrations/2018_02_27_170232_modify_transactions_table_for_stock_transfer.php
+++ b/database/migrations/2018_02_27_170232_modify_transactions_table_for_stock_transfer.php
@@ -14,8 +14,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell', 'expense',
-            'stock_adjustment', 'sell_transfer', 'purchase_transfer', 'opening_stock') DEFAULT NULL");
+        // type column already defined as varchar in initial migration
 
         Schema::table('transactions', function (Blueprint $table) {
             $table->integer('transfer_parent_id')->nullable()->after('total_amount_recovered');

--- a/database/migrations/2018_03_31_140921_update_transactions_table_exchange_rate.php
+++ b/database/migrations/2018_03_31_140921_update_transactions_table_exchange_rate.php
@@ -11,7 +11,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN exchange_rate DECIMAL(20,3) NOT NULL DEFAULT 0');
+        Schema::table('transactions', function ($table) {
+            $table->decimal('exchange_rate', 20, 3)->default(0)->change();
+        });
     }
 
     /**

--- a/database/migrations/2018_04_09_135320_change_exchage_rate_size_in_business_table.php
+++ b/database/migrations/2018_04_09_135320_change_exchage_rate_size_in_business_table.php
@@ -12,8 +12,12 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE business MODIFY COLUMN p_exchange_rate DECIMAL(20, 3) NOT NULL DEFAULT 1');
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN exchange_rate DECIMAL(20,3) NOT NULL DEFAULT 1');
+        Schema::table('business', function ($table) {
+            $table->decimal('p_exchange_rate', 20, 3)->default(1)->change();
+        });
+        Schema::table('transactions', function ($table) {
+            $table->decimal('exchange_rate', 20, 3)->default(1)->change();
+        });
 
         //Update 0 to 1
         DB::table('transactions')

--- a/database/migrations/2018_05_18_191956_add_sell_return_to_transaction_table.php
+++ b/database/migrations/2018_05_18_191956_add_sell_return_to_transaction_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `transactions` CHANGE `type` `type` ENUM('purchase','sell','expense','stock_adjustment','sell_transfer','purchase_transfer','opening_stock','sell_return') DEFAULT NULL");
+        // type column updated to string in base migration; no alteration required
     }
 
     /**

--- a/database/migrations/2018_08_14_104036_add_opening_balance_type_to_transactions_table.php
+++ b/database/migrations/2018_08_14_104036_add_opening_balance_type_to_transactions_table.php
@@ -12,8 +12,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN type ENUM('purchase','sell', 'expense', 'stock_adjustment', 'sell_transfer', 'purchase_transfer', 
-            'opening_stock', 'sell_return', 'opening_balance')");
+        // base migration already stores type as varchar; no change required
     }
 
     /**

--- a/database/migrations/2018_09_27_111609_modify_transactions_table_for_purchase_return.php
+++ b/database/migrations/2018_09_27_111609_modify_transactions_table_for_purchase_return.php
@@ -14,7 +14,7 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN type ENUM('purchase','sell', 'expense', 'stock_adjustment', 'sell_transfer', 'purchase_transfer', 'opening_stock', 'sell_return', 'opening_balance', 'purchase_return') DEFAULT NULL");
+        // type column is varchar in base migration, no alteration needed
 
         Schema::table('transactions', function (Blueprint $table) {
             $table->integer('return_parent_id')->nullable()->after('transfer_parent_id');

--- a/database/migrations/2019_06_28_133732_change_type_column_to_string_in_transactions_table.php
+++ b/database/migrations/2019_06_28_133732_change_type_column_to_string_in_transactions_table.php
@@ -12,11 +12,11 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN type VARCHAR(191) DEFAULT NULL');
-        DB::statement('ALTER TABLE transactions ADD INDEX (type);');
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-        DB::statement('ALTER TABLE  transactions CHANGE  location_id  location_id INT( 10 ) UNSIGNED NULL ;');
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        Schema::table('transactions', function ($table) {
+            $table->string('type')->nullable()->change();
+            $table->unsignedInteger('location_id')->nullable()->change();
+            $table->index('type');
+        });
     }
 
     /**

--- a/database/migrations/2019_11_21_162913_change_quantity_field_types_to_decimal.php
+++ b/database/migrations/2019_11_21_162913_change_quantity_field_types_to_decimal.php
@@ -12,11 +12,17 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE purchase_lines MODIFY COLUMN quantity DECIMAL(22, 4) NOT NULL DEFAULT  '0'");
+        Schema::table('purchase_lines', function ($table) {
+            $table->decimal('quantity', 22, 4)->default(0)->change();
+        });
 
-        DB::statement("ALTER TABLE transaction_sell_lines MODIFY COLUMN quantity DECIMAL(22, 4) NOT NULL DEFAULT  '0'");
+        Schema::table('transaction_sell_lines', function ($table) {
+            $table->decimal('quantity', 22, 4)->default(0)->change();
+        });
 
-        DB::statement("ALTER TABLE transactions MODIFY COLUMN discount_amount DECIMAL(22, 4) DEFAULT  '0'");
+        Schema::table('transactions', function ($table) {
+            $table->decimal('discount_amount', 22, 4)->default(0)->change();
+        });
     }
 
     /**

--- a/database/migrations/2020_07_23_104933_change_status_column_to_varchar_in_transaction_table.php
+++ b/database/migrations/2020_07_23_104933_change_status_column_to_varchar_in_transaction_table.php
@@ -13,7 +13,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transactions MODIFY COLUMN `status` VARCHAR(191) NOT NULL;');
+        Schema::table('transactions', function ($table) {
+            $table->string('status')->change();
+        });
 
         Transaction::where('type', 'sell_transfer')
                 ->update(['status' => 'final']);

--- a/database/migrations/2021_08_25_114932_add_payment_link_fields_to_transaction_payments_table.php
+++ b/database/migrations/2021_08_25_114932_add_payment_link_fields_to_transaction_payments_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE transaction_payments MODIFY COLUMN created_by INT(11) DEFAULT NULL');
+        Schema::table('transaction_payments', function (Blueprint $table) {
+            $table->integer('created_by')->nullable()->change();
+        });
 
         Schema::table('transaction_payments', function (Blueprint $table) {
             $table->boolean('paid_through_link')->default(0)->after('created_by');


### PR DESCRIPTION
## Summary
- refactor transaction creation migration to use strings and include missing fields
- remove raw SQL from various transaction related migrations
- convert ALTER statements to schema builder

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685af781d84883259c1f412dfaec6756